### PR TITLE
Refactoring composition rdbms ingestion

### DIFF
--- a/debussy_concert/data_ingestion/composition/rdbms_ingestion.py
+++ b/debussy_concert/data_ingestion/composition/rdbms_ingestion.py
@@ -2,7 +2,8 @@ from typing import Callable
 
 from debussy_concert.core.movement.movement_base import PMovement
 from debussy_concert.data_ingestion.config.rdbms_data_ingestion import ConfigRdbmsDataIngestion
-from debussy_concert.data_ingestion.config.movement_parameters.rdbms_data_ingestion import RdbmsDataIngestionMovementParameters
+from debussy_concert.data_ingestion.config.movement_parameters.rdbms_data_ingestion import \
+    RdbmsDataIngestionMovementParameters
 from debussy_concert.data_ingestion.composition.base import DataIngestionBase
 from debussy_concert.data_ingestion.movement.data_ingestion import DataIngestionMovement
 from debussy_concert.data_ingestion.phrase.ingestion_to_raw_vault import IngestionSourceToRawVaultStoragePhrase
@@ -26,8 +27,7 @@ class RdbmsIngestionComposition(DataIngestionBase):
         map_ = {
             'mysql': self.mysql_ingestion_movement_builder,
             'mssql': self.mssql_ingestion_movement_builder,
-            'postgresql': self.postgresql_ingestion_movement_builder,
-            'oracle': self.oracle_ingestion_movement_builder
+            'postgresql': self.postgresql_ingestion_movement_builder
         }
         rdbms_name = self.config.source_type.lower()
         builder = map_.get(rdbms_name)
@@ -37,85 +37,53 @@ class RdbmsIngestionComposition(DataIngestionBase):
 
     def mysql_ingestion_movement_builder(
             self, movement_parameters: RdbmsDataIngestionMovementParameters) -> DataIngestionMovement:
-        ingestion_to_raw_vault_phrase = self.mysql_ingestion_to_raw_vault_phrase(movement_parameters)
-        return self.ingestion_movement_builder(
-            movement_parameters=movement_parameters,
-            ingestion_to_raw_vault_phrase=ingestion_to_raw_vault_phrase
-        )
-
-    def mysql_ingestion_to_raw_vault_phrase(self, movement_parameters: RdbmsDataIngestionMovementParameters):
 
         mysql_jdbc_driver = "com.mysql.cj.jdbc.Driver"
-        jdbc_url = "jdbc:mysql://{host}:{port}/" + self.config.source_name
+        mysql_jdbc_url = "jdbc:mysql://{host}:{port}/" + self.config.source_name
 
-        export_mysql_to_gcs_motif = DataprocExportRdbmsTableToGcsMotif(
+        return self.ingestion_movement_builder(
             movement_parameters=movement_parameters,
-            gcs_partition=movement_parameters.data_partitioning.gcs_partition_schema,
-            jdbc_driver=mysql_jdbc_driver,
-            jdbc_url=jdbc_url,
-            main_python_file_uri=self.dataproc_main_python_file_uri
+            ingestion_to_raw_vault_phrase=self.rdbms_ingestion_to_raw_vault_phrase(
+                mysql_jdbc_driver, mysql_jdbc_url, movement_parameters)
         )
-
-        ingestion_to_raw_vault_phrase = IngestionSourceToRawVaultStoragePhrase(
-            export_data_to_storage_motif=export_mysql_to_gcs_motif
-        )
-
-        return ingestion_to_raw_vault_phrase
 
     def mssql_ingestion_movement_builder(
             self, movement_parameters: RdbmsDataIngestionMovementParameters) -> DataIngestionMovement:
-        ingestion_to_raw_vault_phrase = self.mssql_ingestion_to_raw_vault_phrase(movement_parameters)
-        return self.ingestion_movement_builder(
-            movement_parameters=movement_parameters,
-            ingestion_to_raw_vault_phrase=ingestion_to_raw_vault_phrase
-        )
-
-    def mssql_ingestion_to_raw_vault_phrase(self, movement_parameters: RdbmsDataIngestionMovementParameters):
 
         mssql_jdbc_driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-        jdbc_url = "jdbc:sqlserver://{host}:{port};databaseName=" + self.config.source_name
+        mssql_jdbc_url = "jdbc:sqlserver://{host}:{port};databaseName=" + self.config.source_name
 
-        export_mssql_to_gcs_motif = DataprocExportRdbmsTableToGcsMotif(
+        return self.ingestion_movement_builder(
             movement_parameters=movement_parameters,
-            gcs_partition=movement_parameters.data_partitioning.gcs_partition_schema,
-            jdbc_driver=mssql_jdbc_driver,
-            jdbc_url=jdbc_url,
-            main_python_file_uri=self.dataproc_main_python_file_uri
+            ingestion_to_raw_vault_phrase=self.rdbms_ingestion_to_raw_vault_phrase(
+                mssql_jdbc_driver, mssql_jdbc_url, movement_parameters)
         )
-
-        ingestion_to_raw_vault_phrase = IngestionSourceToRawVaultStoragePhrase(
-            export_data_to_storage_motif=export_mssql_to_gcs_motif
-        )
-
-        return ingestion_to_raw_vault_phrase
 
     def postgresql_ingestion_movement_builder(
             self, movement_parameters: RdbmsDataIngestionMovementParameters) -> DataIngestionMovement:
-        ingestion_to_raw_vault_phrase = self.postgresql_ingestion_to_raw_vault_phrase(movement_parameters)
-        return self.ingestion_movement_builder(
-            movement_parameters=movement_parameters,
-            ingestion_to_raw_vault_phrase=ingestion_to_raw_vault_phrase
-        )
-
-    def postgresql_ingestion_to_raw_vault_phrase(self, movement_parameters: RdbmsDataIngestionMovementParameters):
 
         postgresql_jdbc_driver = "org.postgresql.Driver"
-        jdbc_url = "jdbc:postgresql://{host}:{port}/" + self.config.source_name
+        postgresql_jdbc_url = "jdbc:postgresql://{host}:{port}/" + self.config.source_name
 
-        export_postgresql_to_gcs_motif = DataprocExportRdbmsTableToGcsMotif(
+        return self.ingestion_movement_builder(
+            movement_parameters=movement_parameters,
+            ingestion_to_raw_vault_phrase=self.rdbms_ingestion_to_raw_vault_phrase(
+                postgresql_jdbc_driver, postgresql_jdbc_url, movement_parameters)
+        )
+
+    def rdbms_ingestion_to_raw_vault_phrase(
+            self, jdbc_driver, jdbc_url, movement_parameters: RdbmsDataIngestionMovementParameters):
+
+        export_rdbms_to_gcs_motif = DataprocExportRdbmsTableToGcsMotif(
             movement_parameters=movement_parameters,
             gcs_partition=movement_parameters.data_partitioning.gcs_partition_schema,
-            jdbc_driver=postgresql_jdbc_driver,
+            jdbc_driver=jdbc_driver,
             jdbc_url=jdbc_url,
             main_python_file_uri=self.dataproc_main_python_file_uri
         )
 
         ingestion_to_raw_vault_phrase = IngestionSourceToRawVaultStoragePhrase(
-            export_data_to_storage_motif=export_postgresql_to_gcs_motif
+            export_data_to_storage_motif=export_rdbms_to_gcs_motif
         )
 
         return ingestion_to_raw_vault_phrase
-
-    def oracle_ingestion_movement_builder(
-            self, movement_parameters: RdbmsDataIngestionMovementParameters) -> DataIngestionMovement:
-        raise NotImplementedError("Oracle ingestion is not implemented yet")

--- a/examples/mysql_sakila_ingestion/mysql_sakila_ingestion_yamless.py
+++ b/examples/mysql_sakila_ingestion/mysql_sakila_ingestion_yamless.py
@@ -1,0 +1,148 @@
+import datetime as dt
+
+from debussy_concert.core.config.config_environment import ConfigEnvironment
+from debussy_concert.core.config.config_dag_parameters import ConfigDagParameters
+from debussy_concert.data_ingestion.config.rdbms_data_ingestion import ConfigRdbmsDataIngestion
+from debussy_concert.data_ingestion.config.movement_parameters.rdbms_data_ingestion import \
+    RdbmsDataIngestionMovementParameters
+from debussy_concert.data_ingestion.config.movement_parameters.time_partitioned import BigQueryDataPartitioning
+from debussy_concert.data_ingestion.composition.rdbms_ingestion import RdbmsIngestionComposition
+from debussy_concert.core.service.injection import inject_dependencies
+from debussy_concert.core.service.workflow.airflow import AirflowService
+
+config_environment = ConfigEnvironment(
+    project='modular-aileron-191222',
+    region='us-central1',
+    zone='us-central1-a',
+    reverse_etl_bucket='autodelete_dev_bucket',
+    raw_vault_bucket='dotz-datalake-dev-l2-raw-vault',
+    artifact_bucket='dotz-datalake-dev-artifacts',
+    staging_bucket='dotz-datalake-dev-l0-staging',
+    raw_vault_dataset='raw_vault',
+    raw_dataset='raw',
+    trusted_dataset='trusted',
+    reverse_etl_dataset='reverse_etl',
+    temp_dataset='temp',
+    data_lakehouse_connection_id='google_cloud_debussy'
+)
+
+config_dag_parameters = ConfigDagParameters(
+    dag_id="mysql_sakila_ingestion_yamless",
+    default_args={
+        'owner': 'debussy'
+    },
+    description="mysql yamless ingestion example from sakila sample relational database",
+    start_date=dt.datetime(2006, 2, 15),
+    end_date=dt.datetime(2006, 2, 15),
+    catchup=True,
+    schedule_interval='@daily',
+    max_active_runs=1,
+    tags=[
+        'framework:debussy_concert',
+        'project:example',
+        'tier:5',
+        'source:mysql',
+        'type:ingestion',
+        'load:incremental'
+    ]
+)
+
+config_composition = ConfigRdbmsDataIngestion(
+    name='mysql_sakila_ingestion_yamless',
+    description='mysql ingestion yamless',
+    source_type='mysql',
+    source_name='sakila',
+    secret_manager_uri='projects/modular-aileron-191222/secrets/debussy_mysql_dev',
+    dataproc_config={
+        "machine_type": 'n1-standard-2',
+        "num_workers": 0,
+        "subnet": 'subnet-cluster-services',
+        "parallelism": 60,
+        "pip_packages": ['google-cloud-secret-manager']
+    },
+    environment=config_environment,
+    dag_parameters=config_dag_parameters,
+    movements_parameters=[
+        RdbmsDataIngestionMovementParameters(
+            name='category',
+            extract_connection_id='google_cloud_debussy',
+            data_partitioning=BigQueryDataPartitioning(
+                gcs_partition_schema=("_load_flag=incr/_ts_window_start={{ execution_date.strftime('%Y-%m-%d 00:00:00') "
+                                      "}}/_ts_window_end={{ next_execution_date.strftime('%Y-%m-%d 00:00:00') "
+                                      "}}/_ts_logical={{ execution_date.strftime('%Y-%m-%d %H:%M:%S%z') "
+                                      "}}/_ts_ingestion={{ dag_run.start_date.strftime('%Y-%m-%d %H:%M:%S%z') }}"),
+                destination_partition="{{ execution_date.strftime('%Y%m%d') }}"
+            ),
+            raw_table_definition={
+                "fields": [
+                    {
+                        "name": "category_id",
+                        "data_type": "INT64",
+                        "description": "A surrogate primary key used to uniquely identify each category in the table"
+                    },
+                    {
+                        "name": "name",
+                        "data_type": "STRING",
+                        "description": "The name of the category"
+                    },
+                    {
+                        "name": "last_update",
+                        "data_type": "TIMESTAMP",
+                        "description": "When the row was created or most recently updated"
+                    },
+                    {
+                        "name": "_load_flag",
+                        "data_type": "STRING",
+                        "description": "incr = incremental data ingestion; full = full data ingestion"
+                    },
+                    {
+                        "name": "_ts_window_start",
+                        "data_type": "TIMESTAMP",
+                        "description": "Ingestion window start at source timezone"
+                    },
+                    {
+                        "name": "_ts_window_end",
+                        "data_type": "TIMESTAMP",
+                        "description": "Ingestion window end at source timezone"
+                    },
+                    {
+                        "name": "_ts_logical",
+                        "data_type": "TIMESTAMP",
+                        "description": "Airflow logical date"
+                    },
+                    {
+                        "name": "_ts_ingestion",
+                        "data_type": "TIMESTAMP",
+                        "description": "Clock time at Airflow when the ingestion was executed"
+                    },
+                    {
+                        "name": "_hash_key",
+                        "data_type": "STRING",
+                        "description": "An MD5 surrogate hash key used to uniquely identify each record of the source"
+                    }
+                ],
+                "partitioning": {
+                    "field": "_ts_window_start",
+                    "type": "time",
+                    "granularity": "DAY"
+                }
+            },
+            extraction_query=("SELECT category_id, name, last_update "
+                              "FROM sakila.category "
+                              "WHERE last_update >= '{{ execution_date.strftime('%Y-%m-%d 00:00:00') }}' "
+                              "AND last_update   <  '{{ next_execution_date.strftime('%Y-%m-%d 00:00:00') }}' ")
+        )
+    ]
+)
+
+workflow_service = AirflowService()
+
+inject_dependencies(workflow_service, config_composition)
+
+debussy_composition = RdbmsIngestionComposition()
+debussy_composition.dataproc_main_python_file_uri = (
+    f"gs://{config_composition.environment.artifact_bucket}/pyspark-scripts"
+    "/jdbc-to-gcs/jdbc_to_gcs_hash_key.py"
+)
+
+dag = debussy_composition.auto_play()

--- a/examples/mysql_sakila_ingestion/mysql_sakila_ingestion_yamless.py
+++ b/examples/mysql_sakila_ingestion/mysql_sakila_ingestion_yamless.py
@@ -52,7 +52,7 @@ config_composition = ConfigRdbmsDataIngestion(
     description='mysql ingestion yamless',
     source_type='mysql',
     source_name='sakila',
-    secret_manager_uri='projects/modular-aileron-191222/secrets/debussy_mysql_dev',
+    secret_manager_uri=f'projects/{config_environment.project}/secrets/debussy_mysql_dev',
     dataproc_config={
         "machine_type": 'n1-standard-2',
         "num_workers": 0,

--- a/examples/postgresql_sakila_ingestion/composition.yaml
+++ b/examples/postgresql_sakila_ingestion/composition.yaml
@@ -17,6 +17,7 @@ dag_parameters:
   description: Postgresql ingestion for sakila sample relational database.
   catchup: true
   schedule_interval: "0 5 * * *"
+  max_active_runs: 1
   start_date:
     year: 2006
     month: 2

--- a/examples/postgresql_sakila_ingestion/table_schemas/postgresql_sakila_actor.yaml
+++ b/examples/postgresql_sakila_ingestion/table_schemas/postgresql_sakila_actor.yaml
@@ -4,10 +4,10 @@ fields:
     description: A surrogate primary key used to uniquely identify each actor in the table
   - name: first_name
     data_type: STRING
-    description:
+    description: The actor first name
   - name: last_name
     data_type: STRING
-    description:
+    description: The actor last name
   - name: last_update
     data_type: TIMESTAMP
     description: When the row was created or most recently updated

--- a/examples/postgresql_sakila_ingestion/table_schemas/postgresql_sakila_category.yaml
+++ b/examples/postgresql_sakila_ingestion/table_schemas/postgresql_sakila_category.yaml
@@ -4,7 +4,7 @@ fields:
     description: A surrogate primary key used to uniquely identify each category in the table
   - name: name
     data_type: STRING
-    description:
+    description: The name of the category
   - name: last_update
     data_type: TIMESTAMP
     description: When the row was created or most recently updated


### PR DESCRIPTION
Refactoring on rdbms_ingestion composition to improve code reusability:

- Added `rdbms_ingestion_to_raw_vault_phrase`.
- Removed rdbms specific phrases, moving the jdbc parameters to each ingestion builder method.

Improvements on rdbms ingestion examples:

- Add `mysql_sakila_ingestion_yamless`: rdbms ingestion example without the usage of yaml files for environment and composition configuration, and table schema definition.

- Updated `postgresql_sakila_ingestion_daily`: added descriptions to _first_name_ and _last_name_ fields at _actor_ table schema, and description to _name_ field at _category_ table schema; add `max_active_runs ` to `dag_parameters ` at composition yaml file.